### PR TITLE
fix for pypy3.9-v7.3.11

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -390,7 +390,8 @@ PyThreadState_LeaveTracing(PyThreadState *tstate)
 
 
 // bpo-37194 added PyObject_CallNoArgs() to Python 3.9.0a1
-#if PY_VERSION_HEX < 0x030900A1 || defined(PYPY_VERSION)
+// PyObject_CallNoArgs() added to PyPy 3.9.16-v7.3.11
+#if !defined(PyObject_CallNoArgs) && PY_VERSION_HEX < 0x030900A1
 PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallNoArgs(PyObject *func)
 {
@@ -401,7 +402,8 @@ PyObject_CallNoArgs(PyObject *func)
 
 // bpo-39245 made PyObject_CallOneArg() public (previously called
 // _PyObject_CallOneArg) in Python 3.9.0a4
-#if PY_VERSION_HEX < 0x030900A4 || defined(PYPY_VERSION)
+// PyObject_CallOneArg() added to PyPy 3.9.16-v7.3.11
+#if !defined(PyObject_CallOneArg) && PY_VERSION_HEX < 0x030900A4
 PYCAPI_COMPAT_STATIC_INLINE(PyObject*)
 PyObject_CallOneArg(PyObject *func, PyObject *arg)
 {


### PR DESCRIPTION
Python 3.9.16 (feeb267ead3e6771d3f2f49b83e1894839f64fb7, Dec 29 2022, 14:23:21)
PyPy 7.3.11 with GCC 10.2.1 20210130 (Red Hat 10.2.1-11)

Tests run fine on pypy 7.3.11 with those 2 changes

Ran 24 tests in 0.154s

OK

Python 2.7 (release build): 11 C tests succeeded!
Ignore missing Python executable: python3.4
Ignore missing Python executable: python3.5
Ignore missing Python executable: python3.6
Ignore missing Python executable: python3.7
Ignore missing Python executable: python3.8
CPython 3.9 (release build): 11 C tests succeeded!
CPython 3.9 (release build): 11 C++03 tests succeeded!
CPython 3.9 (release build): 11 C++11 tests succeeded!
Ignore missing Python executable: python3.10
Ignore missing Python executable: python3.11
Ignore missing Python executable: python3.12
Ignore missing Python executable: python3-debug
Ignore missing Python executable: pypy
Ignore missing Python executable: pypy2
Ignore missing Python executable: pypy2.7
Ignore missing Python executable: pypy3
Ignore missing Python executable: pypy3.6
Ignore missing Python executable: pypy3.7
Ignore missing Python executable: pypy3.8
Ignore missing Python executable: pypy3.9
PyPy 3.9 (release build): 8 C tests succeeded!
PyPy 3.9 (release build): 8 C++03 tests succeeded!
PyPy 3.9 (release build): 8 C++11 tests succeeded!

Tested: 3 Python executables