### PR TITLE
Add PyObject_HasAttrWithError()

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -46,9 +46,17 @@ Python 3.13
 
    See `PyObject_GetOptionalAttr() documentation <https://docs.python.org/dev/c-api/object.html#c.PyObject_GetOptionalAttr>`__.
 
-.. c:function:: int PyObject_GetOptionalAttrString(PyObject *obj, const char *name, PyObject **result)
+.. c:function:: int PyObject_GetOptionalAttrString(PyObject *obj, const char *attr_name, PyObject **result)
 
    See `PyObject_GetOptionalAttrString() documentation <https://docs.python.org/dev/c-api/object.html#c.PyObject_GetOptionalAttrString>`__.
+
+.. c:function:: int PyObject_HasAttrWithError(PyObject *obj, PyObject *attr_name)
+
+   See `PyObject_HasAttrWithError() documentation <https://docs.python.org/dev/c-api/object.html#c.PyObject_HasAttrWithError>`__.
+
+.. c:function:: int PyObject_HasAttrStringWithError(PyObject *obj, const char *attr_name)
+
+   See `PyObject_HasAttrStringWithError() documentation <https://docs.python.org/dev/c-api/object.html#c.PyObject_HasAttrStringWithError>`__.
 
 .. c:function:: int PyMapping_GetOptionalItem(PyObject *obj, PyObject *key, PyObject **result)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,15 +1,25 @@
 Changelog
 =========
 
+* 2023-09-29: Add functions:
+
+  * ``PyMapping_HasKeyWithError()``
+  * ``PyMapping_HasKeyStringWithError()``
+  * ``PyObject_HasAttrWithError()``
+  * ``PyObject_HasAttrStringWithError()``
+
 * 2023-08-25: Add ``PyDict_ContainsString()`` and ``PyLong_AsInt()`` functions.
 * 2023-08-21: Remove support for Python 2.7, Python 3.4 and older.
 * 2023-08-16: Add ``Py_IsFinalizing()`` function.
 * 2023-07-21: Add ``PyDict_GetItemRef()`` function.
 * 2023-07-18: Add ``PyModule_Add()`` function.
-* 2023-07-12: Add ``PyObject_GetOptionalAttr()``,
-  ``PyObject_GetOptionalAttrString()``,
-  ``PyMapping_GetOptionalItem()``
-  and ``PyMapping_GetOptionalItemString()`` functions.
+* 2023-07-12: Add functions:
+
+  * ``PyObject_GetOptionalAttr()``
+  * ``PyObject_GetOptionalAttrString()``
+  * ``PyMapping_GetOptionalItem()``
+  * ``PyMapping_GetOptionalItemString()``
+
 * 2023-07-05: Add ``PyObject_Vectorcall()`` function.
 * 2023-06-21: Add ``PyWeakref_GetRef()`` function.
 * 2023-06-20: Add ``PyImport_AddModuleRef()`` function.

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -1015,37 +1015,53 @@ test_getattr(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
     if (obj == _Py_NULL) {
         return _Py_NULL;
     }
-    PyObject *attr_name;
-    PyObject *value;
+
+    PyObject *attr_name = create_string("version");
+    PyObject *missing_attr = create_string("nonexistant_attr_name");
 
     // test PyObject_GetOptionalAttr(): attribute exists
-    attr_name = create_string("version");
+    PyObject *value;
     value = UNINITIALIZED_OBJ;
     assert(PyObject_GetOptionalAttr(obj, attr_name, &value) == 1);
     assert(value != _Py_NULL);
     Py_DECREF(value);
-    Py_DECREF(attr_name);
+
+    // test PyObject_HasAttrWithError(): attribute exists
+    assert(PyObject_HasAttrWithError(obj, attr_name) == 1);
 
     // test PyObject_GetOptionalAttrString(): attribute exists
     value = UNINITIALIZED_OBJ;
     assert(PyObject_GetOptionalAttrString(obj, "version", &value) == 1);
+    assert(!PyErr_Occurred());
     assert(value != _Py_NULL);
     Py_DECREF(value);
 
+    // test PyObject_HasAttrStringWithError(): attribute exists
+    assert(PyObject_HasAttrStringWithError(obj, "version") == 1);
+    assert(!PyErr_Occurred());
+
     // test PyObject_GetOptionalAttr(): attribute doesn't exist
-    attr_name = create_string("nonexistant_attr_name");
     value = UNINITIALIZED_OBJ;
-    assert(PyObject_GetOptionalAttr(obj, attr_name, &value) == 0);
+    assert(PyObject_GetOptionalAttr(obj, missing_attr, &value) == 0);
+    assert(!PyErr_Occurred());
     assert(value == _Py_NULL);
-    Py_DECREF(attr_name);
+
+    // test PyObject_HasAttrWithError(): attribute doesn't exist
+    assert(PyObject_HasAttrWithError(obj, missing_attr) == 0);
     assert(!PyErr_Occurred());
 
     // test PyObject_GetOptionalAttrString(): attribute doesn't exist
     value = UNINITIALIZED_OBJ;
     assert(PyObject_GetOptionalAttrString(obj, "nonexistant_attr_name", &value) == 0);
+    assert(!PyErr_Occurred());
     assert(value == _Py_NULL);
+
+    // test PyObject_HasAttrStringWithError(): attribute doesn't exist
+    assert(PyObject_HasAttrStringWithError(obj, "nonexistant_attr_name") == 0);
     assert(!PyErr_Occurred());
 
+    Py_DECREF(attr_name);
+    Py_DECREF(missing_attr);
     Py_DECREF(obj);
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
Add PyObject_HasAttrWithError() and PyObject_HasAttrStringWithError() functions.

Fix PyObject_GetOptionalAttrString(): set result to NULL on error.