### PR TITLE
PyLong_GetSign will be added in 3.14a0

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -1339,8 +1339,8 @@ PyDict_SetDefaultRef(PyObject *d, PyObject *key, PyObject *default_value,
 #endif
 
 
-// gh-116560 added PyLong_GetSign() to Python 3.14a4
-#if PY_VERSION_HEX < 0x030E00A1
+// gh-116560 added PyLong_GetSign() to Python 3.14.0a0
+#if PY_VERSION_HEX < 0x030E00A0
 static inline int PyLong_GetSign(PyObject *obj, int *sign)
 {
     if (!PyLong_Check(obj)) {


### PR DESCRIPTION
Follow on from https://github.com/python/pythoncapi-compat/pull/99.

`PyLong_GetSign` will be added in 3.14.0a0:

* https://github.com/python/cpython/pull/116561

I was getting an error building with latest `main`:

```pytb
      In file included from src/encode.c:28:
      src/thirdparty/pythoncapi_compat.h:1285:1: error: static declaration of 'PyLong_GetSign' follows non-static declaration
      PyLong_GetSign(PyObject *obj, int *sign) {
      ^
      /Users/hugo/github/python/cpython/main/Include/cpython/longobject.h:66:17: note: previous declaration is here
      PyAPI_FUNC(int) PyLong_GetSign(PyObject *v, int *sign);
                      ^
      1 error generated.
```


Fix the version check and comment.