### PR TITLE
Fix 'redefinition; different linkage' errors with cp313-win

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -1537,7 +1537,7 @@ static inline int PyUnicode_Equal(PyObject *str1, PyObject *str2)
     }
 
 #if PY_VERSION_HEX >= 0x030d0000 && !defined(PYPY_VERSION)
-    extern int _PyUnicode_Equal(PyObject *str1, PyObject *str2);
+    PyAPI_FUNC(int) _PyUnicode_Equal(PyObject *str1, PyObject *str2);
 
     return _PyUnicode_Equal(str1, str2);
 #elif PY_VERSION_HEX >= 0x03060000 && !defined(PYPY_VERSION)
@@ -1564,7 +1564,7 @@ static inline PyObject* PyBytes_Join(PyObject *sep, PyObject *iterable)
 static inline Py_hash_t Py_HashBuffer(const void *ptr, Py_ssize_t len)
 {
 #if PY_VERSION_HEX >= 0x03000000 && !defined(PYPY_VERSION)
-    extern Py_hash_t _Py_HashBytes(const void *src, Py_ssize_t len);
+    PyAPI_FUNC(Py_hash_t) _Py_HashBytes(const void *src, Py_ssize_t len);
 
     return _Py_HashBytes(ptr, len);
 #else


### PR DESCRIPTION
After updating mypyc to the latest `pythoncapi_compat.h`, the `cp313-win` wheel builds started to fail.
```
  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.13.0\tools\include\internal\pycore_unicodeobject.h(262): error C2375: '_PyUnicode_Equal': redefinition; different linkage
  D:\a\mypy_mypyc-wheels\mypy_mypyc-wheels\mypy\mypyc\lib-rt\pythoncapi_compat.h(1540): note: see declaration of '_PyUnicode_Equal'

  C:\Users\runneradmin\AppData\Local\pypa\cibuildwheel\Cache\nuget-cpython\python.3.13.0\tools\include\internal\pycore_pyhash.h(24): error C2375: '_Py_HashBytes': redefinition; different linkage
  D:\a\mypy_mypyc-wheels\mypy_mypyc-wheels\mypy\mypyc\lib-rt\pythoncapi_compat.h(1567): note: see declaration of '_Py_HashBytes'
```

https://github.com/mypyc/mypy_mypyc-wheels/actions/runs/11327195039/job/31497783023#step:4:3766

MSVC seems to require that the signature matches the upstream one exactly.

--
The fix here worked for mypyc. Not sure if there is a better one.
/CC @vstinner

--
Refs:
- #110 
- #112
- The mypy PR which broke the wheel builder: https://github.com/python/mypy/pull/17929
- The working fix: https://github.com/python/mypy/pull/17941