### PR TITLE
Update link to latest version

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -23,7 +23,7 @@ Some functions related to frame objects and ``PyThreadState`` are not available
 on PyPy.
 
 Latest version of the header file:
-`pythoncapi_compat.h <https://raw.githubusercontent.com/python/pythoncapi-compat/master/pythoncapi_compat.h>`_.
+`pythoncapi_compat.h <https://raw.githubusercontent.com/python/pythoncapi-compat/main/pythoncapi_compat.h>`_.
 
 
 Python 3.14

--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -7,7 +7,7 @@
 // https://github.com/python/pythoncapi_compat
 //
 // Latest version:
-// https://raw.githubusercontent.com/python/pythoncapi_compat/master/pythoncapi_compat.h
+// https://raw.githubusercontent.com/python/pythoncapi-compat/main/pythoncapi_compat.h
 //
 // SPDX-License-Identifier: 0BSD
 

--- a/upgrade_pythoncapi.py
+++ b/upgrade_pythoncapi.py
@@ -10,7 +10,7 @@ MIN_PYTHON = (2, 7)
 
 
 PYTHONCAPI_COMPAT_URL = ('https://raw.githubusercontent.com/python/'
-                         'pythoncapi_compat/master/pythoncapi_compat.h')
+                         'pythoncapi-compat/main/pythoncapi_compat.h')
 PYTHONCAPI_COMPAT_H = 'pythoncapi_compat.h'
 INCLUDE_PYTHONCAPI_COMPAT = f'#include "{PYTHONCAPI_COMPAT_H}"'
 INCLUDE_PYTHONCAPI_COMPAT2 = f'#include <{PYTHONCAPI_COMPAT_H}>'


### PR DESCRIPTION
The project name changed from using `_` to `-` and the branch name is now `main`.
https://raw.githubusercontent.com/python/pythoncapi-compat/main/pythoncapi_compat.h