### PR TITLE
Relax PYPY_VERSION_NUM requirements for hash macros

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -1204,11 +1204,11 @@ static inline int PyTime_PerfCounter(PyTime_t *result)
 #endif
 
 // gh-111389 added hash constants to Python 3.13.0a5. These constants were
-// added first as private macros to Python 3.4.0b1 and PyPy 7.3.9.
+// added first as private macros to Python 3.4.0b1 and PyPy 7.3.8.
 #if (!defined(PyHASH_BITS) \
      && ((!defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x030400B1) \
          || (defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x03070000 \
-             && PYPY_VERSION_NUM >= 0x07090000)))
+             && PYPY_VERSION_NUM >= 0x07030800)))
 #  define PyHASH_BITS _PyHASH_BITS
 #  define PyHASH_MODULUS _PyHASH_MODULUS
 #  define PyHASH_INF _PyHASH_INF

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -1616,7 +1616,7 @@ test_hash(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
 #if ((!defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x030400B1) \
      || (defined(PYPY_VERSION) && PY_VERSION_HEX >= 0x03070000 \
-         && PYPY_VERSION_NUM >= 0x07090000))
+         && PYPY_VERSION_NUM >= 0x07030800))
     // Just check that constants are available
     size_t bits = PyHASH_BITS;
     assert(bits >= 8);


### PR DESCRIPTION
Those added in
https://github.com/pypy/pypy/commit/5661dff36f1120e458374954ca2353b87b951089 which is available in PyPy 7.3.8+.