### PR TITLE
prepare for pypy3.11 release

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -287,7 +287,7 @@ PyFrame_GetVarString(PyFrameObject *frame, const char *name)
 
 
 // bpo-39947 added PyThreadState_GetInterpreter() to Python 3.9.0a5
-#if PY_VERSION_HEX < 0x030900A5 || defined(PYPY_VERSION)
+#if PY_VERSION_HEX < 0x030900A5 || (defined(PYPY_VERSION) && PY_VERSION_HEX < 0x030B0000)
 static inline PyInterpreterState *
 PyThreadState_GetInterpreter(PyThreadState *tstate)
 {
@@ -918,7 +918,7 @@ static inline int
 PyObject_VisitManagedDict(PyObject *obj, visitproc visit, void *arg)
 {
     PyObject **dict = _PyObject_GetDictPtr(obj);
-    if (*dict == NULL) {
+    if (dict == NULL || *dict == NULL) {
         return -1;
     }
     Py_VISIT(*dict);
@@ -929,7 +929,7 @@ static inline void
 PyObject_ClearManagedDict(PyObject *obj)
 {
     PyObject **dict = _PyObject_GetDictPtr(obj);
-    if (*dict == NULL) {
+    if (dict == NULL || *dict == NULL) {
         return;
     }
     Py_CLEAR(*dict);

--- a/runtests.py
+++ b/runtests.py
@@ -13,7 +13,6 @@ from __future__ import print_function
 import argparse
 import os.path
 import shutil
-import subprocess
 import sys
 try:
     from shutil import which

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -62,7 +62,7 @@ def build_ext():
     display_title("Build test extensions")
     if os.path.exists("build"):
         shutil.rmtree("build")
-    cmd = [sys.executable, "setup.py", "build"]
+    cmd = [sys.executable, "setup.py", "build", "--debug"]
     if VERBOSE:
         run_command(cmd)
         print()

--- a/tests/test_pythoncapi_compat.py
+++ b/tests/test_pythoncapi_compat.py
@@ -62,7 +62,7 @@ def build_ext():
     display_title("Build test extensions")
     if os.path.exists("build"):
         shutil.rmtree("build")
-    cmd = [sys.executable, "setup.py", "build", "--debug"]
+    cmd = [sys.executable, "setup.py", "build"]
     if VERBOSE:
         run_command(cmd)
         print()

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -1432,8 +1432,8 @@ test_long_api(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
 // --- HeapCTypeWithManagedDict --------------------------------------------
 
-// Py_TPFLAGS_MANAGED_DICT was added to Python 3.11.0a3 but is very much an implementation detail
-#if PY_VERSION_HEX >= 0x030B00A3 || ! defined(PYPY_VERSION)
+// Py_TPFLAGS_MANAGED_DICT was added to Python 3.11.0a3 but is not implemented on PyPy
+#if PY_VERSION_HEX >= 0x030B00A3 && ! defined(PYPY_VERSION)
 #  define TEST_MANAGED_DICT
 
 typedef struct {

--- a/tests/test_pythoncapi_compat_cext.c
+++ b/tests/test_pythoncapi_compat_cext.c
@@ -758,7 +758,7 @@ test_import(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 static void
 gc_collect(void)
 {
-#if defined(PYPY_VERSION)
+#if defined(PYPY_VERSION) && PY_VERSION_HEX < 0x030B0000
     PyObject *mod = PyImport_ImportModule("gc");
     assert(mod != _Py_NULL);
 
@@ -1432,8 +1432,8 @@ test_long_api(PyObject *Py_UNUSED(module), PyObject *Py_UNUSED(args))
 
 // --- HeapCTypeWithManagedDict --------------------------------------------
 
-// Py_TPFLAGS_MANAGED_DICT was added to Python 3.11.0a3
-#if PY_VERSION_HEX >= 0x030B00A3
+// Py_TPFLAGS_MANAGED_DICT was added to Python 3.11.0a3 but is very much an implementation detail
+#if PY_VERSION_HEX >= 0x030B00A3 || ! defined(PYPY_VERSION)
 #  define TEST_MANAGED_DICT
 
 typedef struct {


### PR DESCRIPTION
We are working on PyPy3.11. It requires some adjustments here:
- Finally implemented `PyThreadState_GetInterpreter` and `PyGC_Collect`.
- I will argue that the managed dict strategy is an implementation detail. I excluded PyPy3.11 from the test of it, and will make creating a PyTypeObject with that flag enabled an error.
- Currently `_PyObject_GetDictPtr` returns `NULL` on PyPy. That is probably a bug. In any case, the test should not segfault by dereferencing a NULL pointer so I added a check.