### PR TITLE
Fix different linkage error with cp313-win

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -1939,7 +1939,7 @@ PyLongWriter_Finish(PyLongWriter *writer)
 static inline FILE* Py_fopen(PyObject *path, const char *mode)
 {
 #if 0x030400A2 <= PY_VERSION_HEX && !defined(PYPY_VERSION)
-    extern FILE* _Py_fopen_obj(PyObject *path, const char *mode);
+    PyAPI_FUNC(FILE*) _Py_fopen_obj(PyObject *path, const char *mode);
     return _Py_fopen_obj(path, mode);
 #else
     FILE *f;
@@ -2109,7 +2109,7 @@ PyConfig_Get(const char *name)
             return Py_NewRef(value);
         }
 
-        extern const PyConfig* _Py_GetConfig(void);
+        PyAPI_FUNC(const PyConfig*) _Py_GetConfig(void);
         const PyConfig *config = _Py_GetConfig();
         void *member = (char *)config + spec->offset;
         switch (spec->type) {


### PR DESCRIPTION
Seems there was one another regression. Our the `cp313-win` wheel build started to fail after the `pythoncapi_compat.h` update was merged. _We don't test every platform version combination in CI, that's why I missed it initially._

```
  C:/hostedtoolcache/windows/Python/3.13.1/x64/include/internal/pycore_pystate.h(271): error C2375: '_Py_GetConfig': redefinition; different linkage (diff)
  D:/a/mypy/mypy/mypyc/lib-rt/pythoncapi_compat.h(2112): note: see declaration of '_Py_GetConfig' (diff)
```

Seems like a similar issue to #115 where MSVC requires that the signatures match the upstream ones exactly.

_Also updated `_Py_fopen_obj` even though that didn't fail for us. Probably just because we don't use `Py_fopen` yet._