### PR TITLE
Updated readthedocs to latest version of Python

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,7 +4,7 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: ubuntu-lts-latest
   tools:
     python: "3"
 


### PR DESCRIPTION
Rather than specifying an exact Python version in the readthedocs config, use '3', an alias for the latest version - https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-tools-python

Similarly, use the alias for the latest Ubuntu version - https://docs.readthedocs.com/platform/stable/config-file/v2.html#build-os