### PR TITLE
add CI builds for free-threaded Python versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,11 @@ jobs:
           - "3.11"
           - "3.12"
           - "3.13"
+          - "3.13t"
           # CPython 3.14 final is scheduled for October 2025:
           # https://peps.python.org/pep-0719/
           - "3.14"
+          - "3.14t"
 
           # PyPy versions:
           # - https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md
@@ -68,6 +70,8 @@ jobs:
             python: "3.12"
           - os: windows-latest
             python: "3.13"
+          - os: windows-latest
+            python: "3.13t"
 
           # macOS
           # Python 3.9 is the oldest version available on macOS/arm64.
@@ -81,6 +85,8 @@ jobs:
             python: "3.12"
           - os: macos-latest
             python: "3.13"
+          - os: macos-latest
+            python: "3.13t"
 
           # Ubuntu: test deadsnakes Python versions which are not supported by
           # GHA python-versions.


### PR DESCRIPTION
I noticed there weren't any free-threaded builds for #149.