### PR TITLE
Add meson.build file

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,6 @@
+project(
+  'pythoncapi-compat',
+  'c'
+)
+
+incdir = include_directories('.')


### PR DESCRIPTION
This makes it easier to integrate pythoncapi-compat in [Meson](https://mesonbuild.com/) based projects as subproject, as we do for [PyGObject](https://gitlab.gnome.org/GNOME/pygobject/-/blob/main/subprojects/pythoncapi-compat.wrap?ref_type=heads).