### PR TITLE
Fix varargs indicator for PyBytesWriter_Format

### DIFF
--- a/pythoncapi_compat.h
+++ b/pythoncapi_compat.h
@@ -2531,7 +2531,7 @@ PyBytesWriter_WriteBytes(PyBytesWriter *writer,
 
 static inline int
 PyBytesWriter_Format(PyBytesWriter *writer, const char *format, ...)
-                     Py_GCC_ATTRIBUTE((format(printf, 2, 0)));
+                     Py_GCC_ATTRIBUTE((format(printf, 2, 3)));
 
 static inline int
 PyBytesWriter_Format(PyBytesWriter *writer, const char *format, ...)


### PR DESCRIPTION
I made a mistake in the format attribute. The third parameter should point to the location of the varargs arguments.

See https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html#index-format-function-attribute.
